### PR TITLE
Added italian translation

### DIFF
--- a/resources/lang/it/filament-maillog.php
+++ b/resources/lang/it/filament-maillog.php
@@ -1,0 +1,28 @@
+<?php
+
+return [
+    'navigation.group' => 'Logs',
+
+    'navigation.maillog.label' => 'Mail Log',
+    'navigation.maillog.plural-label' => 'Mail Logs',
+
+    'table.heading' => 'Mail Logs',
+
+    'column.status' => 'Stato',
+    'column.subject' => 'Oggetto',
+    'column.to' => 'Destinatario',
+    'column.from' => 'From',
+    'column.cc' => 'Cc',
+    'column.bcc' => 'Ccn',
+    'column.message_id' => 'ID Messaggio',
+    'column.delivered' => 'Consegnato',
+    'column.opened' => 'Aperto',
+    'column.bounced' => 'Rimbalzata',
+    'column.complaint' => 'Reclamo',
+    'column.body' => 'Corpo',
+    'column.headers' => 'Headers',
+    'column.attachments' => 'Allegati',
+    'column.data' => 'Dati',
+    'column.created_at' => 'Creato il',
+    'column.updated_at' => 'Modificato il',
+];


### PR DESCRIPTION
This pull request includes the addition of an Italian language translation file for the mail log feature. The changes involve adding a new file `resources/lang/it/filament-maillog.php` with the necessary translations for various labels and columns related to mail logs.

Translation additions:

* Added `resources/lang/it/filament-maillog.php` with translations for navigation labels, table headings, and column labels related to mail logs.