### PR TITLE
Changed mail_log body to 'longText' because 'text' and added down function

### DIFF
--- a/database/migrations/create_filament_mail_log_table.php.stub
+++ b/database/migrations/create_filament_mail_log_table.php.stub
@@ -15,7 +15,7 @@ return new class extends Migration
             $table->string('cc')->nullable();
             $table->string('bcc')->nullable();
             $table->string('subject');
-            $table->text('body');
+            $table->longText('body');
             $table->text('headers')->nullable();
             $table->longText('attachments')->nullable();
             $table->uuid('message_id')->nullable();
@@ -31,5 +31,10 @@ return new class extends Migration
             $table->index('message_id');
             $table->index('status');
         });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('mail_logs');
     }
 };


### PR DESCRIPTION
This pull request updates the mail log table migration to improve support for larger email bodies and adds a proper rollback method for the migration.

**Database schema improvements:**

* Changed the `body` column type from `text` to `longText` in the `mail_logs` table to allow storing larger email bodies.

**Migration maintenance:**

* Added a `down` method to the migration to ensure the `mail_logs` table can be dropped when rolling back migrations.