### PR TITLE
Add translation support for status column values

### DIFF
--- a/resources/lang/en/filament-maillog.php
+++ b/resources/lang/en/filament-maillog.php
@@ -25,4 +25,10 @@ return [
     'column.data' => 'Data',
     'column.created_at' => 'Created At',
     'column.updated_at' => 'Updated At',
+
+    'status.sent' => 'sent',
+    'status.delivered' => 'delivered',
+    'status.delayed' => 'delayed',
+    'status.complained' => 'complained',
+    'status.bounced' => 'bounced',
 ];

--- a/resources/lang/he/filament-maillog.php
+++ b/resources/lang/he/filament-maillog.php
@@ -1,0 +1,34 @@
+<?php
+
+return [
+    'navigation.group' => 'יומנים',
+
+    'navigation.maillog.label' => 'יומן דוא"ל',
+    'navigation.maillog.plural-label' => 'יומני דוא"ל',
+
+    'table.heading' => 'יומני דוא"ל',
+
+    'column.status' => 'סטטוס',
+    'column.subject' => 'נושא',
+    'column.to' => 'אל',
+    'column.from' => 'מאת',
+    'column.cc' => 'עותק',
+    'column.bcc' => 'עותק מוסתר',
+    'column.message_id' => 'מזהה הודעה',
+    'column.delivered' => 'נמסר',
+    'column.opened' => 'נפתח',
+    'column.bounced' => 'נדחה',
+    'column.complaint' => 'תלונה',
+    'column.body' => 'גוף ההודעה',
+    'column.headers' => 'כותרות',
+    'column.attachments' => 'קבצים מצורפים',
+    'column.data' => 'נתונים',
+    'column.created_at' => 'נוצר בתאריך',
+    'column.updated_at' => 'עודכן בתאריך',
+
+    'status.sent' => 'נשלח',
+    'status.delivered' => 'נמסר',
+    'status.delayed' => 'מתעכב',
+    'status.complained' => 'תלונה',
+    'status.bounced' => 'נדחה',
+];

--- a/src/Resources/MailLogResource/Tables/MailLogsTable.php
+++ b/src/Resources/MailLogResource/Tables/MailLogsTable.php
@@ -20,6 +20,7 @@ class MailLogsTable
             ->columns([
                 TextColumn::make('status')
                     ->label(trans('filament-maillog::filament-maillog.column.status'))
+                    ->formatStateUsing(fn(string $state): string => trans("filament-maillog::filament-maillog.status.{$state}") ?: $state)
                     ->sortable(),
                 TextColumn::make('subject')
                     ->label(trans('filament-maillog::filament-maillog.column.subject'))


### PR DESCRIPTION
## Problem
Currently, the status column in the mail logs table displays raw English values (sent, delivered, delayed, etc.) even when using non-English locales. While column labels are translatable, the actual status values are not.

## Solution
This PR adds `formatStateUsing()` to the status column to enable translation of status values through the translation files.