### PR TITLE
Add methods to decode MIME headers in MailLog

### DIFF
--- a/src/Models/MailLog.php
+++ b/src/Models/MailLog.php
@@ -26,4 +26,14 @@ class MailLog extends Model
     {
         return json_encode($this->data, JSON_PRETTY_PRINT);
     }
+
+    public function getFromAttribute($value)
+    {
+        return mb_decode_mimeheader($value);
+    }
+
+    public function getHeadersAttribute($value)
+    {
+        return mb_decode_mimeheader($value);
+    }
 }


### PR DESCRIPTION
This PR fixes an issue where MIME‑encoded email headers (RFC 2047) were displayed in their raw encoded form, causing accented or non‑ASCII characters to appear incorrectly (e.g., =?utf-8?Q?comp=C3=A9tence?= instead of compétence).

The solution adds Eloquent accessors to automatically decode the from and headers attributes using mb_decode_mimeheader(), ensuring proper display without altering stored data.

I spot this because I'm working in French :)
