### PR TITLE
Fix status column displaying raw translation key instead of label

### DIFF
--- a/resources/lang/en/filament-maillog.php
+++ b/resources/lang/en/filament-maillog.php
@@ -31,4 +31,7 @@ return [
     'status.delayed' => 'delayed',
     'status.complained' => 'complained',
     'status.bounced' => 'bounced',
+    'status.Delivery' => 'delivered',
+    'status.Bounce' => 'bounced',
+    'status.Complaint' => 'complained',
 ];

--- a/resources/lang/he/filament-maillog.php
+++ b/resources/lang/he/filament-maillog.php
@@ -31,4 +31,7 @@ return [
     'status.delayed' => 'מתעכב',
     'status.complained' => 'תלונה',
     'status.bounced' => 'נדחה',
+    'status.Delivery' => 'נמסר',
+    'status.Bounce' => 'נדחה',
+    'status.Complaint' => 'תלונה',
 ];

--- a/resources/lang/it/filament-maillog.php
+++ b/resources/lang/it/filament-maillog.php
@@ -25,4 +25,13 @@ return [
     'column.data' => 'Dati',
     'column.created_at' => 'Creato il',
     'column.updated_at' => 'Modificato il',
+
+    'status.sent' => 'inviato',
+    'status.delivered' => 'consegnato',
+    'status.delayed' => 'ritardato',
+    'status.complained' => 'reclamo',
+    'status.bounced' => 'rimbalzato',
+    'status.Delivery' => 'consegnato',
+    'status.Bounce' => 'rimbalzato',
+    'status.Complaint' => 'reclamo',
 ];

--- a/src/Resources/MailLogResource/Tables/MailLogsTable.php
+++ b/src/Resources/MailLogResource/Tables/MailLogsTable.php
@@ -20,7 +20,15 @@ class MailLogsTable
             ->columns([
                 TextColumn::make('status')
                     ->label(trans('filament-maillog::filament-maillog.column.status'))
-                    ->formatStateUsing(fn (string $state): string => trans("filament-maillog::filament-maillog.status.{$state}") ?: $state)
+                    ->formatStateUsing(function (?string $state): string {
+                        if (blank($state)) {
+                            return '';
+                        }
+                        $key = "filament-maillog::filament-maillog.status.{$state}";
+                        $translated = trans($key);
+
+                        return $translated !== $key ? $translated : $state;
+                    })
                     ->sortable(),
                 TextColumn::make('subject')
                     ->label(trans('filament-maillog::filament-maillog.column.subject'))


### PR DESCRIPTION
## Summary

- Fixed the status column in the Mail Logs table showing the full translation key (e.g. `filament-maillog::filament-maillog.status.Delivery`) instead of a human-readable label
- Added missing translation keys for capitalized AWS SNS event type values (`Delivery`, `Bounce`, `Complaint`) in all three language files (en, he, it)
- Added missing status translations to the Italian language file (it had column labels but no status entries)

## Root Cause

Two bugs:

1. **Wrong fallback logic** — `trans()` returns the full key string when a translation is missing (not `null`/`false`), so `?: $state` never triggered. Fixed by comparing the result against the expected key.
2. **Missing translation keys** — AWS SNS stores event types capitalized (`Delivery`, `Bounce`, `Complaint`), but only lowercase keys (`status.delivered`, `status.bounced`, etc.) existed in the language files.
3. **Null state handling** — The closure typed `string $state` but some records have no status, which would cause a type error. Fixed by accepting `?string` and returning an empty string for blank states.

## Test plan

- [ ] Mail Logs table status column shows "delivered", "bounced", or "complained" for rows with AWS SNS statuses
- [ ] Rows with no status show an empty cell (no error)
- [ ] Rows with lowercase statuses (e.g. `sent`) continue to display correctly
- [ ] Status displays correctly under he and it locales

🤖 Generated with [Claude Code](https://claude.com/claude-code)