### PR TITLE
Harden tenancy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ return [
         'model' => null, // e.g. \App\Models\Team::class
         'relationship_name' => env('FILAMENT_MAILLOG_TENANCY_RELATIONSHIP_NAME', null),
         'column' => env('FILAMENT_MAILLOG_TENANCY_COLUMN', null),
+        'nullable' => env('FILAMENT_MAILLOG_TENANCY_NULLABLE', true),
         'foreign_key' => [
             'on_delete' => env('FILAMENT_MAILLOG_TENANCY_ON_DELETE', 'cascade'),
             'on_update' => env('FILAMENT_MAILLOG_TENANCY_ON_UPDATE', 'cascade'),
@@ -117,6 +118,7 @@ Mail log entries can be scoped to a tenant (e.g. team or organization) when your
        'model' => \App\Models\Team::class,
        'relationship_name' => 'team',
        'column' => 'team_id',
+       'nullable' => true,
        'auto_assign' => true,
    ],
    ```
@@ -137,6 +139,7 @@ Mail log entries can be scoped to a tenant (e.g. team or organization) when your
    Ensure your panel uses the same tenant model, e.g. `->tenant(\App\Models\Team::class)`.
 
 When tenancy is enabled, the resource is scoped to the current tenant and new mail logs are associated with the current tenant.
+The tenant column is nullable by default so emails sent before a tenant context exists, such as registration or verification messages, can still be logged.
 
 ## Testing
 

--- a/config/filament-maillog.php
+++ b/config/filament-maillog.php
@@ -29,6 +29,7 @@ return [
         'model' => null,
         'relationship_name' => env('FILAMENT_MAILLOG_TENANCY_RELATIONSHIP_NAME', null),
         'column' => env('FILAMENT_MAILLOG_TENANCY_COLUMN', null),
+        'nullable' => env('FILAMENT_MAILLOG_TENANCY_NULLABLE', true),
         'foreign_key' => [
             'on_delete' => env('FILAMENT_MAILLOG_TENANCY_ON_DELETE', 'cascade'),
             'on_update' => env('FILAMENT_MAILLOG_TENANCY_ON_UPDATE', 'cascade'),

--- a/database/migrations/create_filament_mail_log_table.php.stub
+++ b/database/migrations/create_filament_mail_log_table.php.stub
@@ -3,6 +3,7 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Tapp\FilamentMailLog\Models\MailLog;
 
 return new class extends Migration
 {
@@ -13,9 +14,21 @@ return new class extends Migration
 
             if (config('filament-maillog.tenancy.enabled')) {
                 $tenantModel = config('filament-maillog.tenancy.model');
-                $table->foreignIdFor($tenantModel)
+
+                if (! is_string($tenantModel) || $tenantModel === '') {
+                    throw new InvalidArgumentException('Tenant model not configured in filament-maillog.tenancy.model');
+                }
+
+                $tenantColumn = $table->foreignIdFor($tenantModel, MailLog::getTenantColumnName());
+
+                if (config('filament-maillog.tenancy.nullable', true)) {
+                    $tenantColumn->nullable();
+                }
+
+                $tenantColumn
                     ->constrained()
-                    ->cascadeOnDelete();
+                    ->onDelete((string) config('filament-maillog.tenancy.foreign_key.on_delete', 'cascade'))
+                    ->onUpdate((string) config('filament-maillog.tenancy.foreign_key.on_update', 'cascade'));
             }
 
             $table->string('from')->nullable();

--- a/tests/Fixtures/Tenant.php
+++ b/tests/Fixtures/Tenant.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tapp\FilamentMailLog\Tests\Fixtures;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Tenant extends Model
+{
+    protected $guarded = [];
+}

--- a/tests/TenancyTest.php
+++ b/tests/TenancyTest.php
@@ -1,0 +1,110 @@
+<?php
+
+use Filament\Facades\Filament;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Tapp\FilamentMailLog\Models\MailLog;
+use Tapp\FilamentMailLog\Resources\MailLogResource;
+use Tapp\FilamentMailLog\Tests\Fixtures\Tenant;
+
+beforeEach(function (): void {
+    Filament::setTenant(null);
+
+    Schema::dropIfExists('mail_logs');
+    Schema::dropIfExists('tenants');
+
+    config()->set('filament-maillog.tenancy.enabled', true);
+    config()->set('filament-maillog.tenancy.model', Tenant::class);
+    config()->set('filament-maillog.tenancy.relationship_name', null);
+    config()->set('filament-maillog.tenancy.column', 'tenant_id');
+    config()->set('filament-maillog.tenancy.nullable', true);
+    config()->set('filament-maillog.tenancy.foreign_key.on_delete', 'cascade');
+    config()->set('filament-maillog.tenancy.foreign_key.on_update', 'cascade');
+    config()->set('filament-maillog.tenancy.auto_assign', true);
+});
+
+afterEach(function (): void {
+    Filament::setTenant(null);
+});
+
+it('adds a nullable tenant foreign key when tenancy is enabled', function (): void {
+    config()->set('filament-maillog.tenancy.column', 'company_id');
+    config()->set('filament-maillog.tenancy.foreign_key.on_delete', 'set null');
+
+    createTenantsTable();
+    migrateMailLogsTable();
+
+    $columns = collect(DB::select('PRAGMA table_info(mail_logs)'))->keyBy('name');
+    $foreignKeys = collect(DB::select('PRAGMA foreign_key_list(mail_logs)'))->keyBy('from');
+
+    expect($columns)->toHaveKey('company_id')
+        ->and($columns->get('company_id')->notnull)->toBe(0)
+        ->and($foreignKeys)->toHaveKey('company_id')
+        ->and($foreignKeys->get('company_id')->on_delete)->toBe('SET NULL');
+});
+
+it('auto assigns the current Filament tenant to new mail logs', function (): void {
+    createTenantsTable();
+    migrateMailLogsTable();
+
+    $tenant = Tenant::query()->create(['name' => 'Acme']);
+
+    Filament::setTenant($tenant, isQuiet: true);
+
+    $mailLog = MailLog::query()->create(mailLogAttributes());
+
+    expect($mailLog->tenant_id)->toBe($tenant->id);
+});
+
+it('allows unassigned mail logs when no tenant context exists', function (): void {
+    createTenantsTable();
+    migrateMailLogsTable();
+
+    $mailLog = MailLog::query()->create(mailLogAttributes());
+
+    expect($mailLog->tenant_id)->toBeNull();
+});
+
+it('scopes the resource query to the current Filament tenant', function (): void {
+    createTenantsTable();
+    migrateMailLogsTable();
+
+    $visibleTenant = Tenant::query()->create(['name' => 'Acme']);
+    $hiddenTenant = Tenant::query()->create(['name' => 'Globex']);
+    $visibleLog = MailLog::query()->create(mailLogAttributes(['tenant_id' => $visibleTenant->id]));
+    MailLog::query()->create(mailLogAttributes(['tenant_id' => $hiddenTenant->id]));
+
+    Filament::setTenant($visibleTenant, isQuiet: true);
+
+    expect(MailLogResource::getEloquentQuery()->pluck('id')->all())->toBe([$visibleLog->id]);
+});
+
+function createTenantsTable(): void
+{
+    Schema::create('tenants', function (Blueprint $table): void {
+        $table->id();
+        $table->string('name');
+        $table->timestamps();
+    });
+}
+
+function migrateMailLogsTable(): void
+{
+    $migration = include __DIR__.'/../database/migrations/create_filament_mail_log_table.php.stub';
+    $migration->up();
+}
+
+/**
+ * @param  array<string, mixed>  $overrides
+ * @return array<string, mixed>
+ */
+function mailLogAttributes(array $overrides = []): array
+{
+    return array_merge([
+        'from' => 'hello@example.com',
+        'to' => 'ada@example.com',
+        'subject' => 'Welcome',
+        'body' => '<p>Welcome to Switchboard.</p>',
+    ], $overrides);
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,6 +2,7 @@
 
 namespace Tapp\FilamentMailLog\Tests;
 
+use Filament\FilamentManager;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Testing\TestResponse;
 use Orchestra\Testbench\TestCase as Orchestra;
@@ -17,6 +18,9 @@ class TestCase extends Orchestra
     protected function setUp(): void
     {
         parent::setUp();
+
+        $this->app->scoped('filament', fn (): FilamentManager => new FilamentManager);
+        $this->app->alias('filament', FilamentManager::class);
 
         Factory::guessFactoryNamesUsing(
             fn (string $modelName) => 'Tapp\\FilamentMailLog\\Database\\Factories\\'.class_basename($modelName).'Factory'


### PR DESCRIPTION
## Summary
- make tenancy migrations honor configured tenant column, nullable setting, and FK actions
- keep tenant columns nullable by default so pre-tenant emails like registration/verification can still be logged
- add coverage for tenant auto-assignment, unassigned mail logs, resource scoping, and migration FK behavior

## Tests
- composer format
- composer analyse
- composer test