### PR TITLE
fix: use text columns for mail address and subject fields

### DIFF
--- a/database/migrations/change_mail_log_address_columns_to_text.php.stub
+++ b/database/migrations/change_mail_log_address_columns_to_text.php.stub
@@ -1,0 +1,19 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('mail_logs', function (Blueprint $table): void {
+            $table->text('from')->nullable()->change();
+            $table->text('to')->nullable()->change();
+            $table->text('cc')->nullable()->change();
+            $table->text('bcc')->nullable()->change();
+            $table->text('subject')->change();
+        });
+    }
+};

--- a/database/migrations/create_filament_mail_log_table.php.stub
+++ b/database/migrations/create_filament_mail_log_table.php.stub
@@ -31,11 +31,11 @@ return new class extends Migration
                     ->onUpdate((string) config('filament-maillog.tenancy.foreign_key.on_update', 'cascade'));
             }
 
-            $table->string('from')->nullable();
-            $table->string('to')->nullable();
-            $table->string('cc')->nullable();
-            $table->string('bcc')->nullable();
-            $table->string('subject');
+            $table->text('from')->nullable();
+            $table->text('to')->nullable();
+            $table->text('cc')->nullable();
+            $table->text('bcc')->nullable();
+            $table->text('subject');
             $table->longText('body');
             $table->text('headers')->nullable();
             $table->longText('attachments')->nullable();

--- a/src/FilamentMailLogServiceProvider.php
+++ b/src/FilamentMailLogServiceProvider.php
@@ -15,7 +15,10 @@ class FilamentMailLogServiceProvider extends PackageServiceProvider
             ->hasConfigFile()
             ->hasViews()
             ->hasTranslations()
-            ->hasMigration('create_filament_mail_log_table');
+            ->hasMigrations([
+                'create_filament_mail_log_table',
+                'change_mail_log_address_columns_to_text',
+            ]);
     }
 
     public function packageBooted(): void

--- a/tests/TenancyTest.php
+++ b/tests/TenancyTest.php
@@ -28,14 +28,25 @@ afterEach(function (): void {
     Filament::setTenant(null);
 });
 
-it('uses text columns for mail address and subject fields', function (): void {
+it('uses text columns for mail address and subject fields in the create migration', function (): void {
     migrateMailLogsTable();
 
-    $columns = collect(DB::select('PRAGMA table_info(mail_logs)'))->keyBy('name');
+    assertMailLogAddressColumnsAreText();
+});
 
-    foreach (['from', 'to', 'cc', 'bcc', 'subject'] as $column) {
-        expect(strtoupper($columns->get($column)->type))->toBe('TEXT');
-    }
+it('can widen address columns on existing mail_logs tables', function (): void {
+    migrateMailLogsTableWithStringColumns();
+    migrateMailLogAddressColumnsToText();
+
+    assertMailLogAddressColumnsAreText();
+});
+
+it('can run the address column change migration more than once', function (): void {
+    migrateMailLogsTableWithStringColumns();
+    migrateMailLogAddressColumnsToText();
+    migrateMailLogAddressColumnsToText();
+
+    assertMailLogAddressColumnsAreText();
 });
 
 it('adds a nullable tenant foreign key when tenancy is enabled', function (): void {
@@ -103,6 +114,34 @@ function migrateMailLogsTable(): void
 {
     $migration = include __DIR__.'/../database/migrations/create_filament_mail_log_table.php.stub';
     $migration->up();
+}
+
+function migrateMailLogsTableWithStringColumns(): void
+{
+    Schema::create('mail_logs', function (Blueprint $table): void {
+        $table->increments('id');
+        $table->string('from')->nullable();
+        $table->string('to')->nullable();
+        $table->string('cc')->nullable();
+        $table->string('bcc')->nullable();
+        $table->string('subject');
+        $table->longText('body');
+    });
+}
+
+function migrateMailLogAddressColumnsToText(): void
+{
+    $migration = include __DIR__.'/../database/migrations/change_mail_log_address_columns_to_text.php.stub';
+    $migration->up();
+}
+
+function assertMailLogAddressColumnsAreText(): void
+{
+    $columns = collect(DB::select('PRAGMA table_info(mail_logs)'))->keyBy('name');
+
+    foreach (['from', 'to', 'cc', 'bcc', 'subject'] as $column) {
+        expect(strtoupper($columns->get($column)->type))->toBe('TEXT');
+    }
 }
 
 /**

--- a/tests/TenancyTest.php
+++ b/tests/TenancyTest.php
@@ -28,6 +28,16 @@ afterEach(function (): void {
     Filament::setTenant(null);
 });
 
+it('uses text columns for mail address and subject fields', function (): void {
+    migrateMailLogsTable();
+
+    $columns = collect(DB::select('PRAGMA table_info(mail_logs)'))->keyBy('name');
+
+    foreach (['from', 'to', 'cc', 'bcc', 'subject'] as $column) {
+        expect(strtoupper($columns->get($column)->type))->toBe('TEXT');
+    }
+});
+
 it('adds a nullable tenant foreign key when tenancy is enabled', function (): void {
     config()->set('filament-maillog.tenancy.column', 'company_id');
     config()->set('filament-maillog.tenancy.foreign_key.on_delete', 'set null');


### PR DESCRIPTION
## Summary
- Changes `from`, `to`, `cc`, `bcc`, and `subject` columns in the published migration stub from `string` (VARCHAR 255) to `text`
- Adds a schema regression test asserting those columns are `TEXT`

## Context
When logging outgoing mail on `MessageSending`, the package stores RFC 2822 address header strings (e.g. `Name <email>, Name <email>`). With multiple BCC recipients that include display names, the combined string can exceed 255 characters, causing the insert to fail and blocking the mail send.

Discovered in CHECK-LMS when wait-list emails with 6–7 trainer BCCs failed (`Data too long for column 'bcc'`).

## Test plan
- [x] `vendor/bin/pest tests/TenancyTest.php --no-coverage`

## Note for existing installs
New installs get the wider columns automatically. Existing apps should run a one-off migration to alter `mail_logs` columns (see TappNetwork/CHECK-LMS#…).


Made with [Cursor](https://cursor.com)