### PR TITLE
Use X-Unique-Id for Cloudflare Email Sending compatibility (1.x)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to `filament-maillog` will be documented in this file.
 
+## Unreleased
+
+### What's Changed
+
+* Use `X-Unique-Id` instead of `unique-id` so Cloudflare Email Sending accepts logged mail headers.
+* Keep SES SNS matching compatible by accepting both `X-Unique-Id` and legacy `unique-id`.
+
 ## v2.0.1 - 2025-12-17
 
 ### What's Changed

--- a/config/filament-maillog.php
+++ b/config/filament-maillog.php
@@ -1,12 +1,14 @@
 <?php
 
+use Tapp\FilamentMailLog\Resources\MailLogResource;
+
 return [
     'amazon-ses' => [
         'configuration-set' => null,
     ],
 
     'resources' => [
-        'MaiLogResource' => \Tapp\FilamentMailLog\Resources\MailLogResource::class,
+        'MaiLogResource' => MailLogResource::class,
     ],
 
     'navigation' => [

--- a/src/Events/MailLogEventHandler.php
+++ b/src/Events/MailLogEventHandler.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Str;
 use Symfony\Component\Mime\Email;
 use Symfony\Component\Mime\Part\DataPart;
 use Tapp\FilamentMailLog\Models\MailLog;
+use Tapp\FilamentMailLog\Support\MailUniqueId;
 
 class MailLogEventHandler
 {
@@ -49,7 +50,7 @@ class MailLogEventHandler
             $event->message->getHeaders()->addTextHeader('X-SES-CONFIGURATION-SET', config('filament-maillog.amazon-ses.configuration-set'));
         }
 
-        $event->message->getHeaders()->addTextHeader('unique-id', $mailLog->message_id);
+        $event->message->getHeaders()->addTextHeader(MailUniqueId::HEADER, $mailLog->message_id);
     }
 
     /**

--- a/src/Http/Controllers/SNSController.php
+++ b/src/Http/Controllers/SNSController.php
@@ -11,6 +11,7 @@ use Illuminate\Http\Response;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Facades\Log;
 use Tapp\FilamentMailLog\Models\MailLog;
+use Tapp\FilamentMailLog\Support\MailUniqueId;
 
 class SNSController extends Controller
 {
@@ -81,12 +82,8 @@ class SNSController extends Controller
         return response()->json([], Response::HTTP_OK);
     }
 
-    private function getUniqueIdFromHeader($messageBody)
+    private function getUniqueIdFromHeader($messageBody): ?string
     {
-        return collect($messageBody['mail']['headers'])->filter(function ($header) {
-            return $header['name'] === 'unique-id';
-        })->map(function ($header) {
-            return $header['value'];
-        })->first();
+        return MailUniqueId::fromSesMailHeaders($messageBody['mail']['headers'] ?? []);
     }
 }

--- a/src/Support/MailUniqueId.php
+++ b/src/Support/MailUniqueId.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tapp\FilamentMailLog\Support;
+
+final class MailUniqueId
+{
+    /**
+     * Cloudflare Email Sending only allows allowlisted headers or X-* custom headers.
+     */
+    public const HEADER = 'X-Unique-Id';
+
+    /**
+     * Legacy header used before Cloudflare compatibility.
+     * Kept for matching in-flight SES SNS notifications.
+     */
+    public const LEGACY_HEADER = 'unique-id';
+
+    /**
+     * @param  array<int, array{name?: string, value?: string}>  $headers
+     */
+    public static function fromSesMailHeaders(array $headers): ?string
+    {
+        foreach ([self::HEADER, self::LEGACY_HEADER] as $headerName) {
+            foreach ($headers as $header) {
+                if (! is_array($header)) {
+                    continue;
+                }
+
+                $name = $header['name'] ?? null;
+                $value = $header['value'] ?? null;
+
+                if (! is_string($name) || ! is_string($value) || $value === '') {
+                    continue;
+                }
+
+                if (strcasecmp($name, $headerName) === 0) {
+                    return $value;
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/tests/MailUniqueIdTest.php
+++ b/tests/MailUniqueIdTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+use Tapp\FilamentMailLog\Support\MailUniqueId;
+
+it('reads the current and legacy unique id headers from SES payloads', function (string $headerName): void {
+    $uniqueId = '019f6b4e-be72-702a-b076-52d42f210fbd';
+
+    expect(MailUniqueId::fromSesMailHeaders([
+        ['name' => 'From', 'value' => 'hello@example.com'],
+        ['name' => $headerName, 'value' => $uniqueId],
+    ]))->toBe($uniqueId);
+})->with([
+    'current header' => [MailUniqueId::HEADER],
+    'legacy header' => [MailUniqueId::LEGACY_HEADER],
+    'case-insensitive current header' => ['x-unique-id'],
+]);
+
+it('prefers the current unique id header when both are present', function (): void {
+    expect(MailUniqueId::fromSesMailHeaders([
+        ['name' => MailUniqueId::LEGACY_HEADER, 'value' => 'legacy-id'],
+        ['name' => MailUniqueId::HEADER, 'value' => 'current-id'],
+    ]))->toBe('current-id');
+});
+
+it('returns null when no unique id header is present', function (): void {
+    expect(MailUniqueId::fromSesMailHeaders([
+        ['name' => 'From', 'value' => 'hello@example.com'],
+    ]))->toBeNull();
+});


### PR DESCRIPTION
## Summary
- Backport of https://github.com/TappNetwork/filament-maillog/pull/48 to the 1.x line
- Emit `X-Unique-Id` instead of `unique-id` when logging outbound mail so Cloudflare Email Sending accepts the payload
- Keep SES SNS matching compatible by accepting both `X-Unique-Id` and legacy `unique-id`

## Test plan
- [x] `vendor/bin/pest tests/MailUniqueIdTest.php`
- [ ] Tag/release as `v1.0.9` after merge so soothsayers / TaxpayerRights can pick it up


Made with [Cursor](https://cursor.com)