### PR TITLE
Add Laravel 13 support to 1.x

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,15 +18,20 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         php: [8.4, 8.3, 8.2]
-        laravel: [12.*, 11.*,10.*]
+        laravel: [13.*, 12.*, 11.*, 10.*]
         stability: [prefer-lowest, prefer-stable]
         include:
+          - laravel: 13.*
+            testbench: 11.*
           - laravel: 12.*
             testbench: 10.*
           - laravel: 11.*
             testbench: 9.*
           - laravel: 10.*
             testbench: 8.*
+        exclude:
+          - laravel: 13.*
+            php: 8.2
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -60,4 +60,4 @@ jobs:
         run: composer show -D
 
       - name: Execute tests
-        run: vendor/bin/pest --ci
+        run: vendor/bin/pest --no-coverage

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 5
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         os: [ubuntu-latest]
         php: [8.4, 8.3, 8.2]
@@ -26,7 +26,7 @@ jobs:
           - laravel: 12.*
             testbench: 10.*
           - laravel: 11.*
-            testbench: 9.*
+            testbench: 9.6.*
           - laravel: 10.*
             testbench: 8.*
         exclude:

--- a/composer.json
+++ b/composer.json
@@ -22,17 +22,17 @@
     "require": {
         "php": "^8.2",
         "aws/aws-php-sns-message-validator": "^1.10",
-        "illuminate/contracts": "^10.0||^11.0||^12.0",
+        "illuminate/contracts": "^10.0||^11.0||^12.0||^13.0",
         "spatie/laravel-package-tools": "^1.16"
     },
     "require-dev": {
         "larastan/larastan": "^2.9||^3.0",
         "laravel/pint": "^1.14",
         "nunomaduro/collision": "^8.1.1||^7.10.0",
-        "orchestra/testbench": "^10.0.0||^9.0.0||^8.22.0",
-        "pestphp/pest": "^3.0||^2.34",
-        "pestphp/pest-plugin-arch": "^3.0||^2.7",
-        "pestphp/pest-plugin-laravel": "^3.0||^2.3",
+        "orchestra/testbench": "^11.0||^10.0.0||^9.0.0||^8.22.0",
+        "pestphp/pest": "^3.0||^2.34||^4.4",
+        "pestphp/pest-plugin-arch": "^3.0||^2.7||^4.0",
+        "pestphp/pest-plugin-laravel": "^3.0||^2.3||^4.1",
         "phpstan/extension-installer": "^1.3||^2.0",
         "phpstan/phpstan-deprecation-rules": "^1.1||^2.0",
         "phpstan/phpstan-phpunit": "^1.3||^2.0",

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "larastan/larastan": "^2.9||^3.0",
         "laravel/pint": "^1.14",
         "nunomaduro/collision": "^8.1.1||^7.10.0",
-        "orchestra/testbench": "^11.0||^10.0.0||^9.0.0||^8.22.0",
+        "orchestra/testbench": "^11.0||^10.0.0||^9.6.0||^8.22.0",
         "pestphp/pest": "^3.0||^2.34||^4.4",
         "pestphp/pest-plugin-arch": "^3.0||^2.7||^4.0",
         "pestphp/pest-plugin-laravel": "^3.0||^2.3||^4.1",


### PR DESCRIPTION
## Summary
- Allow `illuminate/contracts` ^13.0 so Filament 3 apps can run this package on Laravel 13
- Add Orchestra Testbench 11 and Pest 4 to dev dependencies
- Include Laravel 13 in the test matrix (PHP 8.3+)

2.x already has Laravel 13 support (see #34). This ports the constraint to the Filament 3 / 1.x line.

## Test plan
- [ ] CI passes on Laravel 10/11/12/13
- [ ] `composer require tapp/filament-maillog:^1.0` resolves on a Laravel 13 + Filament 3 app


Made with [Cursor](https://cursor.com)