### PR TITLE
Assign mail log tenants for queued notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,10 @@ Mail log entries can be scoped to a tenant (e.g. team or organization) when your
    Ensure your panel uses the same tenant model, e.g. `->tenant(\App\Models\Team::class)`.
 
 When tenancy is enabled, the resource is scoped to the current tenant and new mail logs are associated with the current tenant.
+The current Filament tenant is captured into Laravel's context so queued notifications still get a tenant id after the HTTP request ends.
+
+Notifications can also provide a tenant by implementing `Tapp\FilamentMailLog\Contracts\ProvidesMailLogTenant`, or by exposing a public property that is an instance of the configured tenant model.
+
 The tenant column is nullable by default so emails sent before a tenant context exists, such as registration or verification messages, can still be logged.
 
 ## Testing

--- a/src/Contracts/ProvidesMailLogTenant.php
+++ b/src/Contracts/ProvidesMailLogTenant.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tapp\FilamentMailLog\Contracts;
+
+interface ProvidesMailLogTenant
+{
+    /**
+     * Return the tenant key that should be stored on the mail log.
+     */
+    public function mailLogTenantId(): mixed;
+}

--- a/src/FilamentMailLogServiceProvider.php
+++ b/src/FilamentMailLogServiceProvider.php
@@ -2,9 +2,16 @@
 
 namespace Tapp\FilamentMailLog;
 
+use Filament\Events\TenantSet;
+use Filament\Facades\Filament;
+use Illuminate\Log\Context\Repository as ContextRepository;
+use Illuminate\Notifications\Events\NotificationSending;
+use Illuminate\Support\Facades\Context;
+use Illuminate\Support\Facades\Event;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
 use Tapp\FilamentMailLog\Events\MailLogEventHandler;
+use Tapp\FilamentMailLog\Support\TenantResolver;
 
 class FilamentMailLogServiceProvider extends PackageServiceProvider
 {
@@ -24,5 +31,48 @@ class FilamentMailLogServiceProvider extends PackageServiceProvider
     public function packageBooted(): void
     {
         $this->app['events']->subscribe(MailLogEventHandler::class);
+
+        $this->registerTenantCapture();
+    }
+
+    protected function registerTenantCapture(): void
+    {
+        if (class_exists(Context::class)) {
+            Context::dehydrating(function (ContextRepository $context): void {
+                if (! config('filament-maillog.tenancy.enabled') || ! config('filament-maillog.tenancy.auto_assign', true)) {
+                    return;
+                }
+
+                if ($context->missingHidden(TenantResolver::CONTEXT_KEY) && class_exists(Filament::class)) {
+                    $tenant = Filament::getTenant();
+
+                    if ($tenant) {
+                        $context->addHidden(TenantResolver::CONTEXT_KEY, $tenant->getKey());
+                    }
+                }
+            });
+        }
+
+        if (class_exists(TenantSet::class)) {
+            Event::listen(TenantSet::class, function (TenantSet $event): void {
+                if (! config('filament-maillog.tenancy.enabled') || ! config('filament-maillog.tenancy.auto_assign', true)) {
+                    return;
+                }
+
+                TenantResolver::captureFromTenant($event->getTenant());
+            });
+        }
+
+        Event::listen(NotificationSending::class, function (NotificationSending $event): void {
+            if (! config('filament-maillog.tenancy.enabled') || ! config('filament-maillog.tenancy.auto_assign', true)) {
+                return;
+            }
+
+            if (TenantResolver::currentId() !== null) {
+                return;
+            }
+
+            TenantResolver::capture(TenantResolver::idFromNotification($event->notification));
+        });
     }
 }

--- a/src/Models/Traits/BelongsToTenant.php
+++ b/src/Models/Traits/BelongsToTenant.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Tapp\FilamentMailLog\Models\Traits;
 
-use Filament\Facades\Filament;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Str;
+use Tapp\FilamentMailLog\Support\TenantResolver;
 
 trait BelongsToTenant
 {
@@ -34,14 +34,13 @@ trait BelongsToTenant
                 return;
             }
 
-            $tenantRelationshipName = static::getTenantRelationshipName();
+            $tenantId = TenantResolver::currentId();
 
-            if (class_exists(Filament::class)) {
-                $tenant = Filament::getTenant();
-                if ($tenant) {
-                    $model->{$tenantRelationshipName}()->associate($tenant);
-                }
+            if ($tenantId === null || $tenantId === '') {
+                return;
             }
+
+            $model->{$tenantColumnName} = $tenantId;
         });
     }
 

--- a/src/Support/MailUniqueId.php
+++ b/src/Support/MailUniqueId.php
@@ -18,7 +18,7 @@ final class MailUniqueId
     public const LEGACY_HEADER = 'unique-id';
 
     /**
-     * @param  array<int, array{name?: string, value?: string}>  $headers
+     * @param  array<int, mixed>  $headers
      */
     public static function fromSesMailHeaders(array $headers): ?string
     {

--- a/src/Support/TenantResolver.php
+++ b/src/Support/TenantResolver.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tapp\FilamentMailLog\Support;
+
+use Filament\Facades\Filament;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Context;
+use Tapp\FilamentMailLog\Contracts\ProvidesMailLogTenant;
+
+class TenantResolver
+{
+    public const CONTEXT_KEY = 'filament-maillog.tenant_id';
+
+    public static function currentId(): mixed
+    {
+        if (class_exists(Filament::class)) {
+            $tenant = Filament::getTenant();
+
+            if ($tenant) {
+                return $tenant->getKey();
+            }
+        }
+
+        if (class_exists(Context::class) && Context::hasHidden(self::CONTEXT_KEY)) {
+            return Context::getHidden(self::CONTEXT_KEY);
+        }
+
+        return null;
+    }
+
+    public static function capture(mixed $tenantId): void
+    {
+        if ($tenantId === null || $tenantId === '' || ! class_exists(Context::class)) {
+            return;
+        }
+
+        Context::addHidden(self::CONTEXT_KEY, $tenantId);
+    }
+
+    public static function captureFromTenant(?Model $tenant): void
+    {
+        if ($tenant) {
+            self::capture($tenant->getKey());
+        }
+    }
+
+    public static function idFromNotification(object $notification): mixed
+    {
+        if ($notification instanceof ProvidesMailLogTenant) {
+            return $notification->mailLogTenantId();
+        }
+
+        $tenantModel = config('filament-maillog.tenancy.model');
+
+        if (is_string($tenantModel) && class_exists($tenantModel)) {
+            foreach (get_object_vars($notification) as $value) {
+                if ($value instanceof $tenantModel) {
+                    return $value->getKey();
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/tests/TenancyTest.php
+++ b/tests/TenancyTest.php
@@ -2,14 +2,21 @@
 
 use Filament\Facades\Filament;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Log\Context\Repository as ContextRepository;
+use Illuminate\Notifications\Events\NotificationSending;
+use Illuminate\Support\Facades\Context;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
+use Tapp\FilamentMailLog\Contracts\ProvidesMailLogTenant;
 use Tapp\FilamentMailLog\Models\MailLog;
 use Tapp\FilamentMailLog\Resources\MailLogResource;
 use Tapp\FilamentMailLog\Tests\Fixtures\Tenant;
 
 beforeEach(function (): void {
     Filament::setTenant(null);
+    if (class_exists(Context::class)) {
+        Context::flush();
+    }
 
     Schema::dropIfExists('mail_logs');
     Schema::dropIfExists('tenants');
@@ -85,6 +92,66 @@ it('allows unassigned mail logs when no tenant context exists', function (): voi
     $mailLog = MailLog::query()->create(mailLogAttributes());
 
     expect($mailLog->tenant_id)->toBeNull();
+});
+
+it('assigns a captured Filament tenant after the live tenant is gone', function (): void {
+    createTenantsTable();
+    migrateMailLogsTable();
+
+    $tenant = Tenant::query()->create(['name' => 'Acme']);
+
+    Filament::setTenant($tenant, isQuiet: true);
+
+    $payload = app(ContextRepository::class)->dehydrate();
+
+    Filament::setTenant(null);
+    Context::flush();
+    app(ContextRepository::class)->hydrate($payload);
+
+    $mailLog = MailLog::query()->create(mailLogAttributes());
+
+    expect($mailLog->tenant_id)->toBe($tenant->id);
+});
+
+it('assigns a tenant from a notification that implements ProvidesMailLogTenant', function (): void {
+    createTenantsTable();
+    migrateMailLogsTable();
+
+    $tenant = Tenant::query()->create(['name' => 'Acme']);
+
+    $notification = new class($tenant->id) implements ProvidesMailLogTenant
+    {
+        public function __construct(private mixed $tenantId) {}
+
+        public function mailLogTenantId(): mixed
+        {
+            return $this->tenantId;
+        }
+    };
+
+    event(new NotificationSending((object) ['email' => 'ada@example.com'], $notification, 'mail'));
+
+    $mailLog = MailLog::query()->create(mailLogAttributes());
+
+    expect($mailLog->tenant_id)->toBe($tenant->id);
+});
+
+it('assigns a tenant from a public notification property', function (): void {
+    createTenantsTable();
+    migrateMailLogsTable();
+
+    $tenant = Tenant::query()->create(['name' => 'Acme']);
+
+    $notification = new class($tenant)
+    {
+        public function __construct(public Tenant $tenant) {}
+    };
+
+    event(new NotificationSending((object) ['email' => 'ada@example.com'], $notification, 'mail'));
+
+    $mailLog = MailLog::query()->create(mailLogAttributes());
+
+    expect($mailLog->tenant_id)->toBe($tenant->id);
 });
 
 it('scopes the resource query to the current Filament tenant', function (): void {


### PR DESCRIPTION
# Details

Queued mail was logged without a tenant id. `auto_assign` only reads `Filament::getTenant()`, which is empty on the queue worker.

This captures the current Filament tenant into Laravel context when jobs are dispatched, restores it when the mail log is created, and also accepts a tenant from:

- `Tapp\FilamentMailLog\Contracts\ProvidesMailLogTenant`
- a public notification property that is the configured tenant model

Password reset and other unscoped mail still log with a null tenant.